### PR TITLE
Use the new feature flag for procedural macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //! }
 //! ```
 
-#![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
 
 #[macro_use]
 extern crate cfg_if;


### PR DESCRIPTION
See https://github.com/rustwasm/wasm-bindgen/commit/ed05c7b9454905f15488714619950a55cd3c8d2d

Apparently the feature flag for proc macros was renamed to `use_extern_macros`.