### PR TITLE
Update readme to talk about Error.stackTraceLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ impl MyBigThing {
     }
 }
 ```
+
+### Error.stackTraceLimit
+
+Many browsers only capture the top 10 frames of a stack trace. In rust programs this is less likely to be enough. To see more frames, you can set the non-standard value Error.strackTraceLimit. For more information see the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Microsoft_Extensions/Error.stackTraceLimit) or [v8 docs](https://v8.dev/docs/stack-trace-api).

--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ impl MyBigThing {
 ### Error.stackTraceLimit
 
 Many browsers only capture the top 10 frames of a stack trace. In rust programs this is less likely to be enough. To see more frames, you can set the non-standard value Error.strackTraceLimit. For more information see the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Microsoft_Extensions/Error.stackTraceLimit) or [v8 docs](https://v8.dev/docs/stack-trace-api).
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,11 @@
 //!     }
 //! }
 //! ```
+//!
+//! ## Error.stackTraceLimit
+//!
+//! Many browsers only capture the top 10 frames of a stack trace. In rust programs this is less likely to be enough. To see more frames, you can set the non-standard value Error.strackTraceLimit. For more information see the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Microsoft_Extensions/Error.stackTraceLimit) or [v8 docs](https://v8.dev/docs/stack-trace-api).
+//!
 
 #[macro_use]
 extern crate cfg_if;


### PR DESCRIPTION
Stack traces from rust, including the example screenshots in the existing documentation (!), are often so full of stack frames from the panic mechanism itself and other generic platform functions that there is not enough information to identify where the error was triggered in user code. Hopefully this documentation will save time for the next person who has this problem.