### PR TITLE
Make FireFox Put the @URL Part on Its Own Column

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ cfg_if! {
             let e = Error::new();
             let stack = e.stack();
 
-            // Tweak the stack to separate the '@URL_to_file' part is visually in its own column.
+            // For FireFox: Tweak the stack to separate the '@URL_to_file' part is visually in its own column.
             let mut required_indent = 0;
             for line in stack.lines(){
                 let position = line.find("@").unwrap_or(0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,32 @@ cfg_if! {
             msg.push_str("\n\nStack:\n\n");
             let e = Error::new();
             let stack = e.stack();
-            msg.push_str(&stack);
+
+            // Tweak the stack to separate the '@URL_to_file' part is visually in its own column.
+            let mut required_indent = 0;
+            for line in stack.lines(){
+                let position = line.find("@").unwrap_or(0);
+                if required_indent < position { required_indent = position; }
+            }
+            if 0 < required_indent {
+                required_indent += 3; // Guarantee at least 3 characters between the parts.
+                for line in stack.lines(){
+                    let position = line.find("@").unwrap_or(0);
+                    msg.push_str(&line[..position]);
+                    if position < required_indent {
+                        let difference = required_indent - position;
+                        msg.push_str(" ");
+                        for _ in 0..difference-2 {
+                            msg.push_str(".");
+                        }
+                        msg.push_str(" ");
+                    }
+                    msg.push_str(&line[position..]);
+                    msg.push_str("\n");
+                }
+            } else {
+                msg.push_str(&stack);
+            }
 
             // Safari's devtools, on the other hand, _do_ mess with logged
             // messages' contents, so we attempt to break their heuristics for


### PR DESCRIPTION
On Firefox 72.0.2, noticed that the URL part of the stack trace isn't lined up like in the README. So manually added some periods to space things out.

Here's an example of what I'm seeing:
```
Stack:

init/imports.wbg.__wbg_new_59cb74e423758ede@http://localhost:1234/rust.js:303:23
console_error_panic_hook::Error::new::h21c6f8c021401ca7@http://localhost:1234/rust.wasm:wasm-function[1312]:0x7004a
console_error_panic_hook::hook_impl::h51d369253f11867c@http://localhost:1234/rust.wasm:wasm-function[240]:0x49b09
console_error_panic_hook::hook::h7240c976685d8fda@http://localhost:1234/rust.wasm:wasm-function[1407]:0x7179f
core::ops::function::Fn::call::hd089ec940b4dcbbd@http://localhost:1234/rust.wasm:wasm-function[1318]:0x701f6
std::panicking::rust_panic_with_hook::h4e529e530989255b@http://localhost:1234/rust.wasm:wasm-function[372]:0x543e3
std::panicking::begin_panic::h1f5bf870a56b785e@http://localhost:1234/rust.wasm:wasm-function[512]:0x5b698
BugCraft::game::Game::update::h168b1700ce7fdc84@http://localhost:1234/rust.wasm:wasm-function[16]:0xcd4d
BugCraft::update::hc4c0739190f6c8fa@http://localhost:1234/rust.wasm:wasm-function[1315]:0x70131
update@http://localhost:1234/rust.wasm:wasm-function[1103]:0x6c350
_on_update@http://localhost:1234/typescript.js:341:28
```

## Testing

Verified `cargo test` still passes, that this doesn't affect Chrome, and that Firefox now looks like:
```
Stack:

init/imports.wbg.__wbg_new_59cb74e423758ede ............. @http://localhost:1234/rust.js:303:23
console_error_panic_hook::Error::new::hbe0bf58356f924b2 . @http://localhost:1234/rust.wasm:wasm-function[1405]:0x781b7
console_error_panic_hook::hook_impl::ha653d0da3dbebdd3 .. @http://localhost:1234/rust.wasm:wasm-function[38]:0x24828
console_error_panic_hook::hook::h4e971616aff3a927 ....... @http://localhost:1234/rust.wasm:wasm-function[1510]:0x79b76
core::ops::function::Fn::call::h8f08f944b67fcc08 ........ @http://localhost:1234/rust.wasm:wasm-function[1411]:0x78363
std::panicking::rust_panic_with_hook::h4e529e530989255b . @http://localhost:1234/rust.wasm:wasm-function[407]:0x5a67b
std::panicking::begin_panic::h1f5bf870a56b785e .......... @http://localhost:1234/rust.wasm:wasm-function[561]:0x624d2
BugCraft::game::Game::update::h168b1700ce7fdc84 ......... @http://localhost:1234/rust.wasm:wasm-function[16]:0xcdc3
BugCraft::update::hc4c0739190f6c8fa ..................... @http://localhost:1234/rust.wasm:wasm-function[1408]:0x7829e
update .................................................. @http://localhost:1234/rust.wasm:wasm-function[1188]:0x74269
_on_update .............................................. @http://localhost:1234/typescript.js:341:28
```
