### PR TITLE
Expose panic formatting in API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0/MIT"
 name = "console_error_panic_hook"
 readme = "./README.md"
 repository = "https://github.com/rustwasm/console_error_panic_hook"
-version = "0.1.6"
+version = "0.1.7"
 
 [badges]
 travis-ci = { repository = "rustwasm/console_error_panic_hook" }


### PR DESCRIPTION
Hi, I'm working on an Electron application, Enso. Enso needs to do multiple things in our panic hook: We have an application-specific API to submit the backtrace to, but we'd also like to display it with `console.error`. We want to minimize duplication of the functionality defined in `console_error_panic_hook`--especially the backtrace formatting, since it addresses browser subtleties.

This proposed change introduces a lower level function to the API, exposing the panic formatting functionality for use from another hook.

(Also, it increments the release version in `Cargo.toml` to match the *currently-released* version.)